### PR TITLE
Adjust reader authentication

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/fragment/SettingsFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/SettingsFragment.kt
@@ -5,11 +5,9 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import com.android.mdl.app.R
-import com.android.mdl.app.document.DocumentManager
 import com.android.mdl.app.util.PreferencesHelper.BLE_DATA_RETRIEVAL
 import com.android.mdl.app.util.PreferencesHelper.BLE_DATA_RETRIEVAL_PERIPHERAL_MODE
 import com.android.mdl.app.util.PreferencesHelper.NFC_DATA_RETRIEVAL
-import com.android.mdl.app.util.PreferencesHelper.USE_READER_AUTH
 import com.android.mdl.app.util.PreferencesHelper.WIFI_DATA_RETRIEVAL
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -27,13 +25,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 }
                 true
             }
-            USE_READER_AUTH -> {
-                val documentManager = DocumentManager.getInstance(requireContext())
-                documentManager.provisionMdlDocument()
-                documentManager.provisionMvrDocument()
-                documentManager.provisionMicovDocument()
-                true
-            }
+//            USE_READER_AUTH -> {
+//                val documentManager = DocumentManager.getInstance(requireContext())
+//                documentManager.provisionMdlDocument()
+//                documentManager.provisionMvrDocument()
+//                documentManager.provisionMicovDocument()
+//                true
+//            }
             else -> super.onPreferenceTreeClick(preference)
         }
 

--- a/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
@@ -91,7 +91,7 @@ class TransferDocumentFragment : Fragment() {
                                         readerChain
                                     }
 
-                                    certChain.last().issuerX500Principal.name.split(",")
+                                    certChain.first().subjectX500Principal.name.split(",")
                                         .forEach { line ->
                                             val (key, value) = line.split("=", limit = 2)
                                             if (key == "CN") {

--- a/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
@@ -15,7 +15,7 @@ object PreferencesHelper {
     private const val LOG_SESSION_MESSAGES = "log_session_messages"
     private const val LOG_TRANSPORT = "log_transport"
     private const val LOG_TRANSPORT_VERBOSE = "log_transport_verbose"
-    const val USE_READER_AUTH = "use_reader_authentication"
+//    const val USE_READER_AUTH = "use_reader_authentication"
 
     fun setHardwareBacked(context: Context, isHardwareBacked: Boolean) {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -93,8 +93,10 @@ object PreferencesHelper {
     }
 
     fun isReaderAuthenticationEnabled(context: Context): Boolean {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
-            USE_READER_AUTH, false
-        )
+//        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+//            USE_READER_AUTH, false
+//        )
+        // Just returning false now as we are not using ACP to control the reader authentication
+        return false
     }
 }

--- a/appholder/src/main/res/values/strings.xml
+++ b/appholder/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="bt_ok">OK</string>
     <string name="bio_auth_title">Authenticate to share data</string>
     <string name="bio_auth_subtitle">The verifier is requesting the following information</string>
-    <string name="bio_auth_verifier_subtitle">Verifier %1$s is requesting the following information</string>
+    <string name="bio_auth_verifier_subtitle">Verifier \"%1$s\" is requesting the following information</string>
     <string name="bio_auth_cancel">Cancel</string>
     <string name="bio_auth_failed">User authentication has failed</string>
     <string name="fingerprint_removed_error">Biometric Authentication Error</string>

--- a/appholder/src/main/res/xml/root_preferences.xml
+++ b/appholder/src/main/res/xml/root_preferences.xml
@@ -55,12 +55,12 @@
             app:key="log_transport_verbose"
             app:title="Transport (verbose)" />
     </PreferenceCategory>
-    <PreferenceCategory app:title="Reader Authentication">
-        <SwitchPreference
-            android:defaultValue="false"
-            app:key="use_reader_authentication"
-            app:summary="Reader is using reader certificate"
-            app:title="Use reader authentication" />
-    </PreferenceCategory>
-
+    <!--    For now we are removing the option to use ACP with reader authentication -->
+    <!--    <PreferenceCategory app:title="Reader Authentication">-->
+    <!--        <SwitchPreference-->
+    <!--            android:defaultValue="false"-->
+    <!--            app:key="use_reader_authentication"-->
+    <!--            app:summary="Reader is using reader certificate"-->
+    <!--            app:title="Use reader authentication" />-->
+    <!--    </PreferenceCategory>-->
 </PreferenceScreen>

--- a/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/ReaderCertificateGenerator.java
+++ b/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/ReaderCertificateGenerator.java
@@ -52,7 +52,7 @@ public final class ReaderCertificateGenerator {
 
 			@Override
 			public String subjectDN() {
-				return "C=UT, CN=Google TEST RA mDL";
+				return "C=UT, CN=Google mDoc Reader";
 			}
 
 			@Override


### PR DESCRIPTION
- Renamed common name from reader certificate used by verifier to "Google mDoc Reader""
- Removed option on holder to use reader authetication using ACP when provsioning the documents

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR