### PR TITLE
Add fine location permission back

### DIFF
--- a/appholder/src/main/AndroidManifest.xml
+++ b/appholder/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
         android:required="true" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- As of API 31 BLE doesn't need location permission, but WiFi aware still requires it. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
@@ -36,8 +38,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH"
                      android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-                     android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
                      android:maxSdkVersion="30" />
 
     <!-- Bluetooth permissions for Android 12+ -->

--- a/appholder/src/main/java/com/android/mdl/app/fragment/SelectDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/SelectDocumentFragment.kt
@@ -31,6 +31,7 @@ class SelectDocumentFragment : Fragment() {
     private val appPermissions:Array<String> =
         if (android.os.Build.VERSION.SDK_INT >= 31) {
             arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
                 Manifest.permission.BLUETOOTH_ADVERTISE,
                 Manifest.permission.BLUETOOTH_SCAN,
                 Manifest.permission.BLUETOOTH_CONNECT,

--- a/appverifier/src/main/AndroidManifest.xml
+++ b/appverifier/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
         android:name="android.hardware.nfc"
         android:required="true" />
 
+    <!-- As of API 31 BLE doesn't need location permission, but WiFi aware still requires it. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
@@ -21,8 +23,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH"
                      android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-                     android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
                      android:maxSdkVersion="30" />
 
     <!-- Bluetooth permissions for Android 12+ -->

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
@@ -38,14 +38,15 @@ class DeviceEngagementFragment : Fragment() {
     private val args: DeviceEngagementFragmentArgs by navArgs()
 
     private val appPermissions:List<String> get() {
-        var permissions = mutableListOf(Manifest.permission.CAMERA)
+        var permissions = mutableListOf(
+            Manifest.permission.CAMERA,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        )
 
         if (android.os.Build.VERSION.SDK_INT >= 31) {
             permissions.add(Manifest.permission.BLUETOOTH_ADVERTISE)
             permissions.add(Manifest.permission.BLUETOOTH_SCAN)
             permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
-        } else {
-            permissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
         }
 
         return permissions

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     package="androidx.security.identity.credential">
 
   <uses-permission android:name="android.permission.INTERNET" />
+  <!-- As of API 31 BLE doesn't need location permission, but WiFi aware still requires it. -->
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.LOCAL_MAC_ADDRESS" />
@@ -25,8 +27,6 @@
   <uses-permission android:name="android.permission.BLUETOOTH"
                    android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-                   android:maxSdkVersion="30" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
                    android:maxSdkVersion="30" />
 
   <!-- Bluetooth permissions for Android 12+ -->


### PR DESCRIPTION
It turns out we need this permission for WiFi Aware. The requirement was
dropped for BLE, and I mistakenly thought we no longer needed it for anything.