### PR TITLE
Fix index out of bounds exception for certificate names with escaped commas

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -170,8 +170,7 @@ class ShowDocumentFragment : Fragment() {
             } else {
                 doc.issuerCertificateChain.toList()
             }
-
-            certChain.last().issuerX500Principal.name.split(",").forEach { line ->
+            certChain.last().issuerX500Principal.name.split("[^\\\\],".toRegex()).forEach { line ->
                 val (key, value) = line.split("=", limit = 2)
                 if (key == "CN") {
                     commonName = "($value)"


### PR DESCRIPTION
Is the certificate contains escaped commas, eg.: 

`CN=CLEAR IACA Test,O=Secure Identity\, LLC.,L=New York,ST=New York,C=US`

The display parser for CN will crash with an IndexOutOfBounds exception when attempting to split around `=` pairs.